### PR TITLE
Add NUCLEO-F446 development board

### DIFF
--- a/Marlin/src/HAL/shared/backtrace/unwmemaccess.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwmemaccess.cpp
@@ -63,6 +63,17 @@
   #define START_FLASH_ADDR  0x00000000
   #define END_FLASH_ADDR    0x00080000
 
+#elif defined(NUCLEO_F446)
+
+  // For STM32F446
+  //  SRAM  (0x20000000 - 0x20030000) (128kb)
+  //  FLASH (0x08000000 - 0x08080000) (512kb)
+  //
+  #define START_SRAM_ADDR   0x20000000
+  #define END_SRAM_ADDR     0x20020000
+  #define START_FLASH_ADDR  0x08000000
+  #define END_FLASH_ADDR    0x08080000
+
 #elif defined(STM32F4) || defined(STM32F4xx)
 
   // For STM32F407VET

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -351,6 +351,7 @@
 #define BOARD_FYSETC_S6_V2_0          4218  // FYSETC S6 v2.0 board
 #define BOARD_FLYF407ZG               4219  // FLYF407ZG board (STM32F407ZG)
 #define BOARD_MKS_ROBIN2              4220  // MKS_ROBIN2 (STM32F407ZE)
+#define BOARD_NUCLEO_F446             4221  // ST NUCLEO-F446 Dev Board
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -612,6 +612,8 @@
   #include "stm32f4/pins_MKS_ROBIN2.h"          // STM32F4                                env:MKS_ROBIN2
 #elif MB(FYSETC_S6_V2_0)
   #include "stm32f4/pins_FYSETC_S6_V2_0.h"      // STM32F4                                env:FYSETC_S6
+#elif MB(NUCLEO_F446)
+  #include "stm32f4/pins_NUCLEO_F446.h"         // STM32F4                                env:NUCLEO_F446
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/stm32f4/pins_NUCLEO_F446.h
+++ b/Marlin/src/pins/stm32f4/pins_NUCLEO_F446.h
@@ -1,0 +1,191 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#ifndef STM32F446xx
+  #error "Oops! Select an STM32F446 environment"
+#endif
+
+#define BOARD_INFO_NAME      "NUCLEO-F446"
+#define DEFAULT_MACHINE_NAME "Prototype Board"
+
+#if NO_EEPROM_SELECTED
+  #define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation
+#endif
+
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // Decrease delays and flash wear by spreading writes across the
+  // 128 kB sector allocated for EEPROM emulation.
+  // Not yet supported on F7 hardware
+  // #define FLASH_EEPROM_LEVELING
+#endif
+
+/**
+ * Timer assignments
+ * 
+ * TIM1 -
+ * TIM2 - Hardware PWM (Fan/Heater Pins)
+ * TIM3 - Hardware PWM (Servo Pins)
+ * TIM4 - STEP_TIMER (Marlin)
+ * TIM5 -
+ * TIM6 - TIMER_TONE (variant.h)
+ * TIM7 - TIMER_SERVO (variant.h)
+ * TIM9 - TIMER_SERIAL (platformio.ini)
+ * TIM10 - For some reason trips Watchdog when used for SW Serial
+ * TIM11 -
+ * TIM12 -
+ * TIM13 -
+ * TIM14 - TEMP_TIMER (Marlin)
+ * 
+ */
+#define STEP_TIMER 4
+#define TEMP_TIMER 14
+
+
+/**
+ * These pin assignments are arbitrary and intending for testing purposes.
+ * Assignments may not be ideal, and not every assignment has been tested.
+ * Proceed at your own risk.
+ *
+ *                     _____                                    _____
+ *      (X_STEP) PC10 | · · | PC11 (X_EN)          (X_MIN) PC9 | · · | PC8 (X_MAX)
+ *       (X_DIR) PC12 | · · | PD2 (X_CS)           (Y_MIN) PB8 | · · | PC6 (Y_MAX)
+ *                VDD | · · | E5V                  (Z_MIN) PB9 | · · | PC5
+ *              BOOT0 | · · | GND                         AVDD | · · | U5V
+ *                 NC | · · | NC                           GND | · · | NC
+ *                 NC | · · | IOREF                  "led" PA5 | · · | PA12 (LCD_ENABLE)
+ *      (Y_STEP) PA13 | · · | RESET                 (MISO) PA6 | · · | PA11 (LCD_RS)
+ *       (Y_DIR) PA14 | · · | +3V3                  (MOSI) PA7 | · · | PB12 (LCD_D4)
+ *        (Y_EN) PA15 | · · | +5V                   (SDSS) PB6 | · · | NC
+ *                GND | · · | GND                    (FAN) PC7 | · · | GND
+ *         (Y_CS) PB7 | · · | GND                 (Z_STEP) PA9 | · · | PB2 (Z_EN)
+ *       (Z_MAX) PC13 | · · | VIN                  (Z_DIR) PA8 | · · | PB1 (Z_CS)
+ *      (BEEPER) PC14 | · · | NC                 (E_STEP) PB10 | · · | PB15 (E_EN)
+ *               PC15 | · · | PA0                  (E_DIR) PB4 | · · | PB14 (E_CS)
+ *     (TEMP_BED) PH0 | · · | PA1             (SERVO0_PIN) PB5 | · · | PB13 (SERVO1_PIN)
+ *       (TEMP_0) PH1 | · · | PA4                   (FAN1) PB3 | · · | AGND
+ *               VBAT | · · | PB0            (HEATER_BED) PA10 | · · | PC4 (SCLK)
+ *      (BTN_EN1) PC2 | · · | PC1 (BTN_ENC)     (HEATER_0) PA2 | · · | NC
+ *      (BTN_EN2) PC3 | · · | PC0 (SD_DETECT)   (HEATER_1) PA3 | · · | NC
+ *                     ￣CN7                                    ￣CN10
+ */
+
+#define X_MIN_PIN                           PC9
+#define X_MAX_PIN                           PC8
+#define Y_MIN_PIN                           PB8
+#define Y_MAX_PIN                           PC6
+#define Z_MIN_PIN                           PB9
+#define Z_MAX_PIN                           PC13
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PC10
+#define X_DIR_PIN                           PC12
+#define X_ENABLE_PIN                        PC11
+#define X_CS_PIN                            PD2
+
+#define Y_STEP_PIN                          PA13
+#define Y_DIR_PIN                           PA14
+#define Y_ENABLE_PIN                        PA15
+#define Y_CS_PIN                            PB7
+
+#define Z_STEP_PIN                          PA9
+#define Z_DIR_PIN                           PA8
+#define Z_ENABLE_PIN                        PB2
+#define Z_CS_PIN                            PB1
+
+#define E0_STEP_PIN                         PB10
+#define E0_DIR_PIN                          PB4
+#define E0_ENABLE_PIN                       PB15
+#define E0_CS_PIN                           PB14
+
+#if HAS_TMC_UART
+  #define X_SERIAL_TX_PIN                   X_CS_PIN
+  #define X_SERIAL_RX_PIN                   X_CS_PIN
+
+  #define Y_SERIAL_TX_PIN                   Y_CS_PIN
+  #define Y_SERIAL_RX_PIN                   Y_CS_PIN
+
+  #define Z_SERIAL_TX_PIN                   Z_CS_PIN
+  #define Z_SERIAL_RX_PIN                   Z_CS_PIN
+
+  #define E_SERIAL_TX_PIN                   E0_CS_PIN
+  #define E_SERIAL_RX_PIN                   E0_CS_PIN      
+#endif
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                          PH1
+#define TEMP_BED_PIN                        PH0
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PA2  // PWM Capable, TIM2_CH1
+#define HEATER_BED_PIN                      PA10 // PWM Capable, TIM2_CH2
+
+#ifndef FAN_PIN
+  #define FAN_PIN                           PC7  // PWM Capable, TIM2_CH3
+#endif
+#define FAN1_PIN                            PB3  // PWM Capable, TIM2_CH4
+
+#ifndef E0_AUTO_FAN_PIN
+  #define E0_AUTO_FAN_PIN               FAN1_PIN
+#endif
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PB5  // PWM Capable, TIM3_CH1
+#define SERVO1_PIN                          PB13 // PWM Capable, TIM3_CH2
+
+// SPI for external SD Card (Not entirely sure this will work)
+#define SCK_PIN                             PC4
+#define MISO_PIN                            PA6
+#define MOSI_PIN                            PA7
+#define SS_PIN                              PB6
+#define SDSS                                PB6
+
+#define LED_PIN                             PA5
+
+//
+// LCD / Controller
+//
+#if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+  #define BEEPER_PIN                        PC14  // LCD_BEEPER
+  #define BTN_ENC                           PC1   // BTN_ENC
+  #define SD_DETECT_PIN                     PC0
+  #define LCD_PINS_RS                       PA11  // LCD_RS
+  #define LCD_PINS_ENABLE                   PA12  // LCD_EN
+  #define LCD_PINS_D4                       PB12  // LCD_D4
+  // #define LCD_PINS_D5
+  // #define LCD_PINS_D6
+  // #define LCD_PINS_D7
+  #define BTN_EN1                           PC2   // BTN_EN1
+  #define BTN_EN2                           PC3   // BTN_EN2
+
+  #define BOARD_ST7920_DELAY_1  DELAY_NS(125)
+  #define BOARD_ST7920_DELAY_2  DELAY_NS(63)
+  #define BOARD_ST7920_DELAY_3  DELAY_NS(780)
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -1132,6 +1132,17 @@ upload_protocol   = dfu
 upload_command    = dfu-util -a 0 -s 0x08010000:leave -D "$SOURCE"
 
 #
+# ST NUCLEO-F446 Development Board
+# This environment is for testing purposes prior to control boards
+# being readily available based on STM32F4 MCUs
+#
+[env:NUCLEO_F446]
+platform      = ${common_stm32.platform}
+extends       = common_stm32
+board         = nucleo_f446re
+build_flags   = ${common_stm32.build_flags} -DTIMER_SERIAL=TIM9
+
+#
 # STM32F407VET6 with RAMPS-like shield
 # 'Black' STM32F407VET6 board - https://wiki.stm32duino.com/index.php?title=STM32F407
 # Shield - https://github.com/jmz52/Hardware


### PR DESCRIPTION
added NUCLEO-64 STM32F446 development board support;

tested {X,Y,Z}_{STEP,DIR} and {X,Y,Z}_{MIN,MAX} pins.

again here as happened in #5 there was the need to use some I/O pin instead than others ( for example I needed to move Z_MAX from PC5 to PC13 even I not understand exactly the reason:

![image](https://user-images.githubusercontent.com/13405008/94354023-48f42480-0077-11eb-8782-ec7f4456d6f3.png)
